### PR TITLE
feat(intune): add Apple VPP / DEP token metrics scraping and corresponding tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The exporter requires the following permissions to be set in the Entra ID app re
 - Sites.Read.All
 - TeamSettings.Read.All
 - User.Read.All
+- DeviceManagementServiceConfig.Read.All
 
 Keep in mind, after granting the permissions, the administrator must consent to them.
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The exporter requires the following permissions to be set in the Entra ID app re
 
 - DeviceManagementConfiguration.Read.All
 - DeviceManagementManagedDevices.Read.All
+- DeviceManagementServiceConfig.Read.All
 - Directory.Read.All
 - Files.Read.All
 - Organization.Read.All
@@ -75,7 +76,6 @@ The exporter requires the following permissions to be set in the Entra ID app re
 - Sites.Read.All
 - TeamSettings.Read.All
 - User.Read.All
-- DeviceManagementServiceConfig.Read.All
 
 Keep in mind, after granting the permissions, the administrator must consent to them.
 

--- a/cmd/m365-exporter/main.go
+++ b/cmd/m365-exporter/main.go
@@ -199,7 +199,7 @@ func setupMetricsCollectors(
 			enabled:   v.GetBool(conf.KeyServiceHealthEnabled),
 		},
 		{
-			collector: intune.NewCollector(logger, tenantID, msGraphClient),
+			collector: intune.NewCollector(logger, tenantID, msGraphClient, httpClient),
 			interval:  3 * time.Hour,
 			enabled:   v.GetBool(conf.KeyIntuneEnabled),
 		},

--- a/docs/collector.intune.md
+++ b/docs/collector.intune.md
@@ -49,13 +49,13 @@ m365_intune_device_count{os_name="iOS",os_version="17.7",tenant="0000000-0000-00
 m365_intune_device_count{os_name="iOS",os_version="18.0",tenant="0000000-0000-0000-0000-000000000000"} 1
 # HELP m365_intune_vpp_status Status of Apple VPP tokens (0=unknown, 1=valid, 2=expired, 3=invalid, 4=assigned_to_external_mdm)
 # TYPE m365_intune_vpp_status gauge
-m365_intune_vpp_status{appleId="example@company.appleid.com",id="9ceb2f92-2f92-9ceb-922f-eb9c922feb9c",organizationName="Example Organization",tenant="0000000-0000-0000-0000-000000000000"} 1
+m365_intune_vpp_status{appleId="example@company.appleid.com",id="0000000-0000-0000-0000-000000000000",organizationName="Example Organization",tenant="0000000-0000-0000-0000-000000000000"} 1
 # HELP m365_intune_vpp_expiry Expiration timestamp of Apple VPP tokens in Unix timestamp
 # TYPE m365_intune_vpp_expiry gauge
-m365_intune_vpp_expiry{appleId="example@company.appleid.com",id="9ceb2f92-2f92-9ceb-922f-eb9c922feb9c",organizationName="Example Organization",tenant="0000000-0000-0000-0000-000000000000"} 1.782552802e+09
+m365_intune_vpp_expiry{appleId="example@company.appleid.com",id="0000000-0000-0000-0000-000000000000",organizationName="Example Organization",tenant="0000000-0000-0000-0000-000000000000"} 1.782552802e+09
 # HELP m365_intune_dep_token_expiry Expiration timestamp of Apple DEP onboarding tokens in Unix timestamp
 # TYPE m365_intune_dep_token_expiry gauge
-m365_intune_dep_token_expiry{appleIdentifier="example@company.appleid.com",id="40342229-2229-4034-2922-344029223440",tenantId="0000000-0000-0000-0000-000000000000",tenant="0000000-0000-0000-0000-000000000000"} 1.735689594e+09
+m365_intune_dep_token_expiry{appleIdentifier="example@company.appleid.com",id="0000000-0000-0000-0000-000000000000",tenantId="0000000-0000-0000-0000-000000000000",tenant="0000000-0000-0000-0000-000000000000"} 1.735689594e+09
 ```
 
 ## Useful queries

--- a/docs/collector.intune.md
+++ b/docs/collector.intune.md
@@ -8,13 +8,13 @@ None
 
 ## Metrics
 
-| Name                            | Description                                               | Type  | Labels                                    |
-|---------------------------------|-----------------------------------------------------------|-------|-------------------------------------------|
-| `m365_intune_device_compliance` | Compliance of devices managed by Intune                   | Gauge | `tenant`, `type`                          |
-| `m365_intune_device_count`      | Device information of devices managed by Intune           | Gauge | `tenant`, `os_name`, `os_version`         |
-| `m365_intune_vpp_status`        | Status of VPP tokens (0=unknown, 1=valid, 2=expired, 3=invalid, 4=assigned_to_external_mdm) | Gauge | `tenant`, `appleId`, `organizationName`, `id` |
-| `m365_intune_vpp_expiry`        | Expiration timestamp of VPP tokens in Unix timestamp      | Gauge | `tenant`, `appleId`, `organizationName`, `id` |
-| `m365_intune_dep_token_expiry`  | Expiration timestamp of DEP onboarding tokens in Unix timestamp | Gauge | `tenant`, `appleIdentifier`, `id`, `tenantId` |
+| Name                            | Description                                                                                       | Type  | Labels                                    |
+|---------------------------------|---------------------------------------------------------------------------------------------------|-------|-------------------------------------------|
+| `m365_intune_device_compliance` | Compliance of devices managed by Intune                                                           | Gauge | `tenant`, `type`                          |
+| `m365_intune_device_count`      | Device information of devices managed by Intune                                                   | Gauge | `tenant`, `os_name`, `os_version`         |
+| `m365_intune_vpp_status`        | Status of Apple VPP tokens (0=unknown, 1=valid, 2=expired, 3=invalid, 4=assigned_to_external_mdm) | Gauge | `tenant`, `appleId`, `organizationName`, `id` |
+| `m365_intune_vpp_expiry`        | Expiration timestamp of Apple VPP tokens in Unix timestamp                                        | Gauge | `tenant`, `appleId`, `organizationName`, `id` |
+| `m365_intune_dep_token_expiry`  | Expiration timestamp of Apple DEP onboarding tokens in Unix timestamp                             | Gauge | `tenant`, `appleIdentifier`, `id`, `tenantId` |
 
 ## Example metric
 
@@ -47,13 +47,13 @@ m365_intune_device_count{os_name="iOS",os_version="17.5.1",tenant="0000000-0000-
 m365_intune_device_count{os_name="iOS",os_version="17.6.1",tenant="0000000-0000-0000-0000-000000000000"} 4
 m365_intune_device_count{os_name="iOS",os_version="17.7",tenant="0000000-0000-0000-0000-000000000000"} 1
 m365_intune_device_count{os_name="iOS",os_version="18.0",tenant="0000000-0000-0000-0000-000000000000"} 1
-# HELP m365_intune_vpp_status Status of VPP tokens (0=unknown, 1=valid, 2=expired, 3=invalid, 4=assigned_to_external_mdm)
+# HELP m365_intune_vpp_status Status of Apple VPP tokens (0=unknown, 1=valid, 2=expired, 3=invalid, 4=assigned_to_external_mdm)
 # TYPE m365_intune_vpp_status gauge
 m365_intune_vpp_status{appleId="example@company.appleid.com",id="9ceb2f92-2f92-9ceb-922f-eb9c922feb9c",organizationName="Example Organization",tenant="0000000-0000-0000-0000-000000000000"} 1
-# HELP m365_intune_vpp_expiry Expiration timestamp of VPP tokens in Unix timestamp
+# HELP m365_intune_vpp_expiry Expiration timestamp of Apple VPP tokens in Unix timestamp
 # TYPE m365_intune_vpp_expiry gauge
 m365_intune_vpp_expiry{appleId="example@company.appleid.com",id="9ceb2f92-2f92-9ceb-922f-eb9c922feb9c",organizationName="Example Organization",tenant="0000000-0000-0000-0000-000000000000"} 1.782552802e+09
-# HELP m365_intune_dep_token_expiry Expiration timestamp of DEP onboarding tokens in Unix timestamp
+# HELP m365_intune_dep_token_expiry Expiration timestamp of Apple DEP onboarding tokens in Unix timestamp
 # TYPE m365_intune_dep_token_expiry gauge
 m365_intune_dep_token_expiry{appleIdentifier="example@company.appleid.com",id="40342229-2229-4034-2922-344029223440",tenantId="0000000-0000-0000-0000-000000000000",tenant="0000000-0000-0000-0000-000000000000"} 1.735689594e+09
 ```

--- a/docs/collector.intune.md
+++ b/docs/collector.intune.md
@@ -8,10 +8,12 @@ None
 
 ## Metrics
 
-| Name                            | Description                                               | Type  | Labels                            |
-|---------------------------------|-----------------------------------------------------------|-------|-----------------------------------|
-| `m365_intune_device_compliance` | Compliance of devices managed by Intune                   | Gauge | `tenant`, `type`                  |
-| `m365_intune_device_count`      | Device information of devices managed by Intune           | Gauge | `tenant`, `os_name`, `os_version` |
+| Name                            | Description                                               | Type  | Labels                                    |
+|---------------------------------|-----------------------------------------------------------|-------|-------------------------------------------|
+| `m365_intune_device_compliance` | Compliance of devices managed by Intune                   | Gauge | `tenant`, `type`                          |
+| `m365_intune_device_count`      | Device information of devices managed by Intune           | Gauge | `tenant`, `os_name`, `os_version`         |
+| `m365_intune_vpp_status`        | Status of VPP tokens (0=unknown, 1=valid, 2=expired, 3=invalid, 4=assigned_to_external_mdm) | Gauge | `tenant`, `appleId`, `organizationName`   |
+| `m365_intune_vpp_expiry`        | Expiration timestamp of VPP tokens in Unix timestamp      | Gauge | `tenant`, `appleId`, `organizationName`   |
 
 ## Example metric
 
@@ -44,6 +46,12 @@ m365_intune_device_count{os_name="iOS",os_version="17.5.1",tenant="0000000-0000-
 m365_intune_device_count{os_name="iOS",os_version="17.6.1",tenant="0000000-0000-0000-0000-000000000000"} 4
 m365_intune_device_count{os_name="iOS",os_version="17.7",tenant="0000000-0000-0000-0000-000000000000"} 1
 m365_intune_device_count{os_name="iOS",os_version="18.0",tenant="0000000-0000-0000-0000-000000000000"} 1
+# HELP m365_intune_vpp_status Status of VPP tokens (0=unknown, 1=valid, 2=expired, 3=invalid, 4=assigned_to_external_mdm)
+# TYPE m365_intune_vpp_status gauge
+m365_intune_vpp_status{appleId="example@company.appleid.com",organizationName="Example Organization",tenant="0000000-0000-0000-0000-000000000000"} 1
+# HELP m365_intune_vpp_expiry Expiration timestamp of VPP tokens in Unix timestamp
+# TYPE m365_intune_vpp_expiry gauge
+m365_intune_vpp_expiry{appleId="example@company.appleid.com",organizationName="Example Organization",tenant="0000000-0000-0000-0000-000000000000"} 1.782552802e+09
 ```
 
 ## Useful queries

--- a/docs/collector.intune.md
+++ b/docs/collector.intune.md
@@ -14,7 +14,7 @@ None
 | `m365_intune_device_count`      | Device information of devices managed by Intune                                                   | Gauge | `tenant`, `os_name`, `os_version`         |
 | `m365_intune_vpp_status`        | Status of Apple VPP tokens (0=unknown, 1=valid, 2=expired, 3=invalid, 4=assigned_to_external_mdm) | Gauge | `tenant`, `appleId`, `organizationName`, `id` |
 | `m365_intune_vpp_expiry`        | Expiration timestamp of Apple VPP tokens in Unix timestamp                                        | Gauge | `tenant`, `appleId`, `organizationName`, `id` |
-| `m365_intune_dep_token_expiry`  | Expiration timestamp of Apple DEP onboarding tokens in Unix timestamp                             | Gauge | `tenant`, `appleIdentifier`, `id`, `tenantId` |
+| `m365_intune_dep_token_expiry`  | Expiration timestamp of Apple DEP onboarding tokens in Unix timestamp                             | Gauge | `tenant`, `appleIdentifier`, `id`              |
 
 ## Example metric
 

--- a/docs/collector.intune.md
+++ b/docs/collector.intune.md
@@ -12,8 +12,9 @@ None
 |---------------------------------|-----------------------------------------------------------|-------|-------------------------------------------|
 | `m365_intune_device_compliance` | Compliance of devices managed by Intune                   | Gauge | `tenant`, `type`                          |
 | `m365_intune_device_count`      | Device information of devices managed by Intune           | Gauge | `tenant`, `os_name`, `os_version`         |
-| `m365_intune_vpp_status`        | Status of VPP tokens (0=unknown, 1=valid, 2=expired, 3=invalid, 4=assigned_to_external_mdm) | Gauge | `tenant`, `appleId`, `organizationName`   |
-| `m365_intune_vpp_expiry`        | Expiration timestamp of VPP tokens in Unix timestamp      | Gauge | `tenant`, `appleId`, `organizationName`   |
+| `m365_intune_vpp_status`        | Status of VPP tokens (0=unknown, 1=valid, 2=expired, 3=invalid, 4=assigned_to_external_mdm) | Gauge | `tenant`, `appleId`, `organizationName`, `id` |
+| `m365_intune_vpp_expiry`        | Expiration timestamp of VPP tokens in Unix timestamp      | Gauge | `tenant`, `appleId`, `organizationName`, `id` |
+| `m365_intune_dep_token_expiry`  | Expiration timestamp of DEP onboarding tokens in Unix timestamp | Gauge | `tenant`, `appleIdentifier`, `id`, `tenantId` |
 
 ## Example metric
 
@@ -48,10 +49,13 @@ m365_intune_device_count{os_name="iOS",os_version="17.7",tenant="0000000-0000-00
 m365_intune_device_count{os_name="iOS",os_version="18.0",tenant="0000000-0000-0000-0000-000000000000"} 1
 # HELP m365_intune_vpp_status Status of VPP tokens (0=unknown, 1=valid, 2=expired, 3=invalid, 4=assigned_to_external_mdm)
 # TYPE m365_intune_vpp_status gauge
-m365_intune_vpp_status{appleId="example@company.appleid.com",organizationName="Example Organization",tenant="0000000-0000-0000-0000-000000000000"} 1
+m365_intune_vpp_status{appleId="example@company.appleid.com",id="9ceb2f92-2f92-9ceb-922f-eb9c922feb9c",organizationName="Example Organization",tenant="0000000-0000-0000-0000-000000000000"} 1
 # HELP m365_intune_vpp_expiry Expiration timestamp of VPP tokens in Unix timestamp
 # TYPE m365_intune_vpp_expiry gauge
-m365_intune_vpp_expiry{appleId="example@company.appleid.com",organizationName="Example Organization",tenant="0000000-0000-0000-0000-000000000000"} 1.782552802e+09
+m365_intune_vpp_expiry{appleId="example@company.appleid.com",id="9ceb2f92-2f92-9ceb-922f-eb9c922feb9c",organizationName="Example Organization",tenant="0000000-0000-0000-0000-000000000000"} 1.782552802e+09
+# HELP m365_intune_dep_token_expiry Expiration timestamp of DEP onboarding tokens in Unix timestamp
+# TYPE m365_intune_dep_token_expiry gauge
+m365_intune_dep_token_expiry{appleIdentifier="example@company.appleid.com",id="40342229-2229-4034-2922-344029223440",tenantId="0000000-0000-0000-0000-000000000000",tenant="0000000-0000-0000-0000-000000000000"} 1.735689594e+09
 ```
 
 ## Useful queries

--- a/pkg/collectors/intune/intune.go
+++ b/pkg/collectors/intune/intune.go
@@ -56,7 +56,6 @@ type Collector struct {
 	abstract.BaseCollector
 
 	logger *slog.Logger
-	tenant string
 
 	complianceDesc *prometheus.Desc
 	osDesc         *prometheus.Desc

--- a/pkg/collectors/intune/intune.go
+++ b/pkg/collectors/intune/intune.go
@@ -91,7 +91,7 @@ func NewCollector(logger *slog.Logger, tenant string, msGraphClient *msgraphsdk.
 		),
 		vppStatusDesc: prometheus.NewDesc(
 			prometheus.BuildFQName(abstract.Namespace, subsystem, "vpp_status"),
-			"Status of VPP tokens (0=unknown, 1=valid, 2=expired, 3=invalid, 4=assigned_to_external_mdm)",
+			"Status of Apple VPP tokens (0=unknown, 1=valid, 2=expired, 3=invalid, 4=assigned_to_external_mdm)",
 			[]string{"appleId", "organizationName", "id"},
 			prometheus.Labels{
 				"tenant": tenant,
@@ -99,7 +99,7 @@ func NewCollector(logger *slog.Logger, tenant string, msGraphClient *msgraphsdk.
 		),
 		vppExpiryDesc: prometheus.NewDesc(
 			prometheus.BuildFQName(abstract.Namespace, subsystem, "vpp_expiry"),
-			"Expiration timestamp of VPP tokens in Unix timestamp",
+			"Expiration timestamp of Apple VPP tokens in Unix timestamp",
 			[]string{"appleId", "organizationName", "id"},
 			prometheus.Labels{
 				"tenant": tenant,
@@ -107,7 +107,7 @@ func NewCollector(logger *slog.Logger, tenant string, msGraphClient *msgraphsdk.
 		),
 		depExpiryDesc: prometheus.NewDesc(
 			prometheus.BuildFQName(abstract.Namespace, subsystem, "dep_token_expiry"),
-			"Expiration timestamp of DEP onboarding tokens in Unix timestamp",
+			"Expiration timestamp of Apple DEP onboarding tokens in Unix timestamp",
 			[]string{"appleIdentifier", "id", "tenantId"},
 			prometheus.Labels{
 				"tenant": tenant,

--- a/pkg/collectors/intune/intune.go
+++ b/pkg/collectors/intune/intune.go
@@ -71,7 +71,6 @@ func NewCollector(logger *slog.Logger, tenant string, msGraphClient *msgraphsdk.
 	return &Collector{
 		BaseCollector: abstract.NewBaseCollector(msGraphClient, subsystem),
 		logger:        logger.With(slog.String("collector", subsystem)),
-		tenant:        tenant,
 
 		complianceDesc: prometheus.NewDesc(
 			prometheus.BuildFQName(abstract.Namespace, subsystem, "device_compliance"),
@@ -108,7 +107,7 @@ func NewCollector(logger *slog.Logger, tenant string, msGraphClient *msgraphsdk.
 		depExpiryDesc: prometheus.NewDesc(
 			prometheus.BuildFQName(abstract.Namespace, subsystem, "dep_token_expiry"),
 			"Expiration timestamp of Apple DEP onboarding tokens in Unix timestamp",
-			[]string{"appleIdentifier", "id", "tenantId"},
+			[]string{"appleIdentifier", "id"},
 			prometheus.Labels{
 				"tenant": tenant,
 			},
@@ -412,7 +411,6 @@ func (c *Collector) scrapeDepOnboardingSettings(ctx context.Context) ([]promethe
 			expiryValue,
 			depSetting.AppleIdentifier,
 			depSetting.ID,
-			c.tenant, // tenantId is constant (the tenant we're monitoring)
 		)
 		metrics = append(metrics, metric)
 	}

--- a/pkg/collectors/intune/intune_test.go
+++ b/pkg/collectors/intune/intune_test.go
@@ -38,7 +38,7 @@ func TestCollector_scrapeDevices(t *testing.T) {
 	httpClient := httpclient.New(prometheus.NewRegistry())
 	httpClient.WithAzureCredential(azureCredential)
 
-	collector := NewCollector(logger, tenantID, msGraphClient)
+	collector := NewCollector(logger, tenantID, msGraphClient, httpClient.GetHTTPClient())
 
 	// TODO: Go 1.24: Change to t.Context()
 	metrics, err := collector.scrapeDevices(context.Background())
@@ -75,7 +75,7 @@ func TestCollector_scrapeVppTokens(t *testing.T) {
 	httpClient := httpclient.New(prometheus.NewRegistry())
 	httpClient.WithAzureCredential(azureCredential)
 
-	collector := NewCollector(logger, tenantID, msGraphClient)
+	collector := NewCollector(logger, tenantID, msGraphClient, httpClient.GetHTTPClient())
 
 	// TODO: Go 1.24: Change to t.Context()
 	metrics, err := collector.scrapeVppTokens(context.Background())

--- a/pkg/collectors/intune/intune_test.go
+++ b/pkg/collectors/intune/intune_test.go
@@ -6,15 +6,33 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"sync"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/cloudeteer/m365-exporter/internal/testutil"
 	"github.com/cloudeteer/m365-exporter/pkg/auth"
 	"github.com/cloudeteer/m365-exporter/pkg/httpclient"
+	msgraphsdk "github.com/microsoftgraph/msgraph-sdk-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+var (
+	msGraphClientOnce sync.Once
+	msGraphClient     *msgraphsdk.GraphServiceClient
+	azureCredential   *azidentity.DefaultAzureCredential
+	msGraphClientErr  error
+)
+
+func getMSGraphClient(t *testing.T) (*msgraphsdk.GraphServiceClient, *azidentity.DefaultAzureCredential) {
+	msGraphClientOnce.Do(func() {
+		msGraphClient, azureCredential, msGraphClientErr = auth.NewMSGraphClient(http.DefaultClient)
+	})
+	require.NoError(t, msGraphClientErr)
+	return msGraphClient, azureCredential
+}
 
 func TestCollector_scrapeDevices(t *testing.T) {
 	t.Parallel()
@@ -31,9 +49,7 @@ func TestCollector_scrapeDevices(t *testing.T) {
 	// TODO: Go 1.24: Change to slog.NewDiscardHandler
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	// TODO: make this a singleton for all tests
-	msGraphClient, azureCredential, err := auth.NewMSGraphClient(http.DefaultClient)
-	require.NoError(t, err)
+	msGraphClient, azureCredential := getMSGraphClient(t)
 
 	httpClient := httpclient.New(prometheus.NewRegistry())
 	httpClient.WithAzureCredential(azureCredential)
@@ -68,9 +84,7 @@ func TestCollector_scrapeVppTokens(t *testing.T) {
 	// TODO: Go 1.24: Change to slog.NewDiscardHandler
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	// TODO: make this a singleton for all tests
-	msGraphClient, azureCredential, err := auth.NewMSGraphClient(http.DefaultClient)
-	require.NoError(t, err)
+	msGraphClient, azureCredential := getMSGraphClient(t)
 
 	httpClient := httpclient.New(prometheus.NewRegistry())
 	httpClient.WithAzureCredential(azureCredential)
@@ -90,5 +104,42 @@ func TestCollector_scrapeVppTokens(t *testing.T) {
 	if len(metrics) > 0 {
 		assert.Contains(t, allMetrics, "m365_intune_vpp_status")
 		assert.Contains(t, allMetrics, "m365_intune_vpp_expiry")
+	}
+}
+
+func TestCollector_scrapeDepOnboardingSettings(t *testing.T) {
+	t.Parallel()
+
+	var (
+		ok       bool
+		tenantID string
+	)
+
+	if tenantID, ok = os.LookupEnv("AZURE_TENANT_ID"); !ok {
+		t.Skip("no AZURE_TENANT_ID environment variable set")
+	}
+
+	// TODO: Go 1.24: Change to slog.NewDiscardHandler
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	msGraphClient, azureCredential := getMSGraphClient(t)
+
+	httpClient := httpclient.New(prometheus.NewRegistry())
+	httpClient.WithAzureCredential(azureCredential)
+
+	collector := NewCollector(logger, tenantID, msGraphClient, httpClient.GetHTTPClient())
+
+	// TODO: Go 1.24: Change to t.Context()
+	metrics, err := collector.scrapeDepOnboardingSettings(context.Background())
+	require.NoError(t, err)
+
+	// DEP onboarding settings might not exist in all tenants, so we just check that the function doesn't error
+	// and returns metrics (even if empty)
+	allMetrics, err := testutil.MetricsToText(t, metrics)
+	require.NoError(t, err)
+
+	// If DEP onboarding settings exist, we should see the metrics
+	if len(metrics) > 0 {
+		assert.Contains(t, allMetrics, "m365_intune_dep_token_expiry")
 	}
 }

--- a/pkg/httpclient/httpclient.go
+++ b/pkg/httpclient/httpclient.go
@@ -96,6 +96,15 @@ func (c *HTTPClient) WithAzureCredential(cred azcore.TokenCredential) {
 			}
 
 			req.Header.Set("Authorization", "Bearer "+token.Token)
+		case req.Host == "graph.microsoft.com":
+			token, err := cred.GetToken(req.Context(), policy.TokenRequestOptions{
+				Scopes: []string{"https://graph.microsoft.com/.default"},
+			})
+			if err != nil {
+				return nil, fmt.Errorf("getting token: %w", err)
+			}
+
+			req.Header.Set("Authorization", "Bearer "+token.Token)
 		case strings.HasSuffix(req.Host, "-admin.sharepoint.com"):
 			token, err := cred.GetToken(req.Context(), policy.TokenRequestOptions{
 				Scopes: []string{fmt.Sprintf("https://%s/.default", req.Host)},


### PR DESCRIPTION
do reduce the amount of dependencies and build time i did not use graph sdk beta for this one request and instead went with "plane" http requests

this pr add metrics for Apple / Intune related metrics to avoid expiring tokens

closes #62 