### PR TITLE
feat(intune): add per-profile device configuration status metric

### DIFF
--- a/cmd/m365-exporter/main.go
+++ b/cmd/m365-exporter/main.go
@@ -200,9 +200,12 @@ func setupMetricsCollectors(
 			enabled:   v.GetBool(conf.KeyServiceHealthEnabled),
 		},
 		{
-			collector: intune.NewCollector(logger, tenantID, msGraphClient, httpClient),
-			interval:  3 * time.Hour,
-			enabled:   v.GetBool(conf.KeyIntuneEnabled),
+			collector: intune.NewCollector(logger, tenantID, msGraphClient, httpClient, intune.Settings{
+				PerProfileConfiguration:       v.GetBool(conf.KeyIntunePerProfileConfiguration),
+				PerProfileConfigurationFilter: v.GetStringSlice(conf.KeyIntunePerProfileConfigurationFilter),
+			}),
+			interval: 3 * time.Hour,
+			enabled:  v.GetBool(conf.KeyIntuneEnabled),
 		},
 		{
 			collector: onedrive.NewCollector(logger, tenantID, msGraphClient, onedrive.Settings{

--- a/docs/collector.intune.md
+++ b/docs/collector.intune.md
@@ -4,7 +4,10 @@ The intune collector collects metrics and status about managed devices.
 
 ## Configuration
 
-None
+| Key                                    | Type     | Default | Description                                                                 |
+|----------------------------------------|----------|---------|-----------------------------------------------------------------------------|
+| `intune.perProfileConfiguration`       | `bool`   | `false` | Enable per-device, per-profile configuration status metrics (opt-in due to high cardinality) |
+| `intune.perProfileConfigurationFilter` | `[]string` | `[]`  | Glob patterns to filter profiles by name (empty = all profiles). Case-insensitive, OR logic. |
 
 ## Metrics
 
@@ -16,6 +19,7 @@ None
 | `m365_intune_vpp_expiry`        | Expiration timestamp of Apple VPP tokens in Unix timestamp                                        | Gauge | `tenant`, `appleId`, `organizationName`, `id` |
 | `m365_intune_dep_token_expiry`  | Expiration timestamp of Apple DEP onboarding tokens in Unix timestamp                             | Gauge | `tenant`, `appleId`, `id`              |
 | `m365_intune_apn_expiry`        | Expiration timestamp of Apple Push Notification Certificate in Unix timestamp                      | Gauge | `tenant`, `appleId`, `topicIdentifier`, `id` |
+| `m365_intune_device_configuration_overview` | Per-profile device configuration status aggregate counts. Opt-in via `intune.perProfileConfiguration: true`. | Gauge | `tenant`, `profile_name`, `status` |
 
 ## Example metric
 
@@ -62,8 +66,42 @@ m365_intune_dep_token_expiry{appleId="example@company.appleid.com",id="0000000-0
 m365_intune_apn_expiry{appleId="example@company.appleid.com",topicIdentifier="com.apple.mgmt.External.example-uuid",id="0000000-0000-0000-0000-000000000000",tenant="0000000-0000-0000-0000-000000000000"} 1.782552802e+09
 ```
 
+### Per-profile configuration (opt-in)
+
+When `intune.perProfileConfiguration: true` is set:
+
+```
+# HELP m365_intune_device_configuration_overview Per-profile device configuration status aggregate counts
+# TYPE m365_intune_device_configuration_overview gauge
+m365_intune_device_configuration_overview{profile_name="Windows Configuration Profile",status="success",tenant="0000000-0000-0000-0000-000000000000"} 29
+m365_intune_device_configuration_overview{profile_name="Windows Configuration Profile",status="failed",tenant="0000000-0000-0000-0000-000000000000"} 0
+m365_intune_device_configuration_overview{profile_name="Windows Configuration Profile",status="error",tenant="0000000-0000-0000-0000-000000000000"} 0
+m365_intune_device_configuration_overview{profile_name="Windows Configuration Profile",status="pending",tenant="0000000-0000-0000-0000-000000000000"} 0
+m365_intune_device_configuration_overview{profile_name="Windows Configuration Profile",status="notApplicable",tenant="0000000-0000-0000-0000-000000000000"} 0
+```
+
 ## Useful queries
-__This collector does not yet have any useful queries added, we would appreciate your help adding them!__
+
+```promql
+# Failed device count per profile
+m365_intune_device_configuration_overview{status="failed"}
+
+# Total non-compliant devices across all profiles
+sum(m365_intune_device_configuration_overview{status=~"failed|error"})
+
+# Success rate per profile
+sum by (profile_name) (m365_intune_device_configuration_overview{status="success"})
+/
+sum by (profile_name) (m365_intune_device_configuration_overview{status!="notApplicable"})
+```
 
 ## Alerting examples
-__This collector does not yet have alerting examples, we would appreciate your help adding them!__
+
+```promql
+# Alert: any profile has failed devices
+m365_intune_device_configuration_overview{status="failed"} > 0
+
+# Alert: profile has >10% failure rate
+(m365_intune_device_configuration_overview{status="failed"} /
+ (m365_intune_device_configuration_overview{status="success"} + m365_intune_device_configuration_overview{status="failed"})) > 0.1
+```

--- a/docs/m365-exporter-config.yaml
+++ b/docs/m365-exporter-config.yaml
@@ -23,6 +23,8 @@ servicehealth:
   enabled: true
 intune:
   enabled: true
+  perPolicyCompliance: false
+  perPolicyComplianceFilter: []
 entraid:
   enabled: true
 sharepoint:

--- a/pkg/collectors/intune/intune.go
+++ b/pkg/collectors/intune/intune.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"path"
 	"slices"
 	"strings"
 	"time"
@@ -34,6 +35,9 @@ const (
 
 	// URLDepOnboardingSettings DEP Onboarding Settings API URL
 	URLDepOnboardingSettings = "https://graph.microsoft.com/beta/deviceManagement/depOnboardingSettings"
+
+	// URLDeviceConfigurations Device Configuration Profiles API URL
+	URLDeviceConfigurations = "https://graph.microsoft.com/beta/deviceManagement/deviceConfigurations"
 )
 
 // Interface guard.
@@ -52,25 +56,74 @@ type depOnboardingSettingsResponse struct {
 	Value []depOnboardingSetting `json:"value"`
 }
 
+// Settings holds configuration for the Intune collector.
+type Settings struct {
+	PerProfileConfiguration       bool
+	PerProfileConfigurationFilter []string
+}
+
+type configurationProfile struct {
+	ID          string `json:"id"`
+	DisplayName string `json:"displayName"`
+}
+
+type configurationProfileListResponse struct {
+	Value    []configurationProfile `json:"value"`
+	NextLink string                 `json:"@odata.nextLink"`
+}
+
+type deviceConfigurationStatusOverview struct {
+	ID                   string `json:"id"`
+	SuccessCount         int    `json:"successCount"`
+	FailedCount          int    `json:"failedCount"`
+	ErrorCount           int    `json:"errorCount"`
+	PendingCount         int    `json:"pendingCount"`
+	NotApplicableCount   int    `json:"notApplicableCount"`
+	ConfigurationVersion int    `json:"configurationVersion"`
+	LastUpdateDateTime   string `json:"lastUpdateDateTime"`
+}
+
 type Collector struct {
 	abstract.BaseCollector
 
 	logger *slog.Logger
 
-	complianceDesc *prometheus.Desc
-	osDesc         *prometheus.Desc
-	vppStatusDesc  *prometheus.Desc
-	vppExpiryDesc  *prometheus.Desc
-	depExpiryDesc  *prometheus.Desc
-	apnExpiryDesc  *prometheus.Desc
+	complianceDesc              *prometheus.Desc
+	osDesc                      *prometheus.Desc
+	vppStatusDesc               *prometheus.Desc
+	vppExpiryDesc               *prometheus.Desc
+	depExpiryDesc               *prometheus.Desc
+	apnExpiryDesc               *prometheus.Desc
+	perProfileConfigurationDesc *prometheus.Desc
 
-	httpClient *http.Client
+	httpClient        *http.Client
+	perProfileEnabled bool
+	profileFilter     []string
 }
 
-func NewCollector(logger *slog.Logger, tenant string, msGraphClient *msgraphsdk.GraphServiceClient, httpClient *http.Client) *Collector {
+func NewCollector(
+	logger *slog.Logger,
+	tenant string,
+	msGraphClient *msgraphsdk.GraphServiceClient,
+	httpClient *http.Client,
+	settings Settings,
+) *Collector {
+	collectorLogger := logger.With(slog.String("collector", subsystem))
+
+	// Validate glob patterns at startup
+	for _, pattern := range settings.PerProfileConfigurationFilter {
+		_, err := path.Match(pattern, "test")
+		if err != nil {
+			collectorLogger.Warn("invalid glob pattern in perProfileConfigurationFilter, will be skipped during filtering",
+				slog.String("pattern", pattern),
+				slog.Any("err", err),
+			)
+		}
+	}
+
 	return &Collector{
 		BaseCollector: abstract.NewBaseCollector(msGraphClient, subsystem),
-		logger:        logger.With(slog.String("collector", subsystem)),
+		logger:        collectorLogger,
 
 		complianceDesc: prometheus.NewDesc(
 			prometheus.BuildFQName(abstract.Namespace, subsystem, "device_compliance"),
@@ -120,8 +173,18 @@ func NewCollector(logger *slog.Logger, tenant string, msGraphClient *msgraphsdk.
 				"tenant": tenant,
 			},
 		),
+		perProfileConfigurationDesc: prometheus.NewDesc(
+			prometheus.BuildFQName(abstract.Namespace, subsystem, "device_configuration_overview"),
+			"Per-profile device configuration status aggregate counts",
+			[]string{"profile_name", "status"},
+			prometheus.Labels{
+				"tenant": tenant,
+			},
+		),
 
-		httpClient: httpClient,
+		httpClient:        httpClient,
+		perProfileEnabled: settings.PerProfileConfiguration,
+		profileFilter:     toLowerSlice(settings.PerProfileConfigurationFilter),
 	}
 }
 
@@ -143,6 +206,10 @@ func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.depExpiryDesc
 
 	ch <- c.apnExpiryDesc
+
+	if c.perProfileEnabled {
+		ch <- c.perProfileConfigurationDesc
+	}
 }
 
 func (c *Collector) ScrapeMetrics(ctx context.Context) ([]prometheus.Metric, error) {
@@ -173,7 +240,16 @@ func (c *Collector) ScrapeMetrics(ctx context.Context) ([]prometheus.Metric, err
 		errs = append(errs, fmt.Errorf("error scraping apple push notification certificate metrics: %w", err))
 	}
 
-	return slices.Concat(complianceMetrics, osMetrics, vppMetrics, depMetrics, apnMetrics), errors.Join(errs...)
+	var perProfileMetrics []prometheus.Metric
+
+	if c.perProfileEnabled {
+		perProfileMetrics, err = c.scrapePerProfileConfiguration(ctx)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("error scraping per-profile configuration metrics: %w", err))
+		}
+	}
+
+	return slices.Concat(complianceMetrics, osMetrics, vppMetrics, depMetrics, apnMetrics, perProfileMetrics), errors.Join(errs...)
 }
 
 func (c *Collector) scrapeCompliance(ctx context.Context) ([]prometheus.Metric, error) {
@@ -380,37 +456,11 @@ func (c *Collector) scrapeVppTokens(ctx context.Context) ([]prometheus.Metric, e
 }
 
 func (c *Collector) scrapeDepOnboardingSettings(ctx context.Context) ([]prometheus.Metric, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, URLDepOnboardingSettings, nil)
-	if err != nil {
-		return nil, fmt.Errorf("error creating request: %w", err)
-	}
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("error sending request: %w", err)
-	}
-
-	defer func() {
-		err := resp.Body.Close()
-		if err != nil {
-			c.logger.ErrorContext(ctx, "error closing response body", slog.Any("err", err))
-		}
-	}()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("error reading response body: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code %d: %s", resp.StatusCode, string(body))
-	}
-
 	var depResponse depOnboardingSettingsResponse
 
-	err = json.Unmarshal(body, &depResponse)
+	err := c.getJSON(ctx, URLDepOnboardingSettings, &depResponse)
 	if err != nil {
-		return nil, fmt.Errorf("error unmarshalling response: body %s, error %w", string(body), err)
+		return nil, fmt.Errorf("error fetching DEP onboarding settings: %w", err)
 	}
 
 	metrics := make([]prometheus.Metric, 0, len(depResponse.Value))
@@ -484,4 +534,185 @@ func (c *Collector) scrapeApplePushNotificationCertificate(ctx context.Context) 
 	metrics = append(metrics, metric)
 
 	return metrics, nil
+}
+
+func (c *Collector) getJSON(ctx context.Context, url string, target any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("error sending request: %w", err)
+	}
+
+	defer func() {
+		err := resp.Body.Close()
+		if err != nil {
+			c.logger.ErrorContext(ctx, "error closing response body", slog.Any("err", err))
+		}
+	}()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("error reading response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status code %d: %s", resp.StatusCode, string(body))
+	}
+
+	err = json.Unmarshal(body, target)
+	if err != nil {
+		return fmt.Errorf("error unmarshalling response: body %s, error %w", string(body), err)
+	}
+
+	return nil
+}
+
+func (c *Collector) fetchAllConfigurationProfiles(ctx context.Context) ([]configurationProfile, error) {
+	all := make([]configurationProfile, 0, 50)
+
+	url := URLDeviceConfigurations + "?$select=id,displayName"
+
+	for url != "" {
+		var resp configurationProfileListResponse
+
+		err := c.getJSON(ctx, url, &resp)
+		if err != nil {
+			return nil, fmt.Errorf("error fetching configuration profiles: %w", err)
+		}
+
+		all = append(all, resp.Value...)
+		url = resp.NextLink
+	}
+
+	return all, nil
+}
+
+func (c *Collector) fetchProfileStatusOverview(ctx context.Context, profileID string) (*deviceConfigurationStatusOverview, error) {
+	url := URLDeviceConfigurations + "/" + profileID + "/deviceStatusOverview"
+
+	var overview deviceConfigurationStatusOverview
+
+	err := c.getJSON(ctx, url, &overview)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching status overview for profile %s: %w", profileID, err)
+	}
+
+	return &overview, nil
+}
+
+func (c *Collector) scrapePerProfileConfiguration(ctx context.Context) ([]prometheus.Metric, error) {
+	start := time.Now()
+
+	profiles, err := c.fetchAllConfigurationProfiles(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching configuration profiles: %w", err)
+	}
+
+	// Pre-allocate for 5 metrics per profile (5 status types)
+	metrics := make([]prometheus.Metric, 0, len(profiles)*5)
+
+	for _, profile := range profiles {
+		profileName := profile.DisplayName
+
+		if profileName == "" {
+			profileName = unknownValue
+		}
+
+		if !c.matchesProfileFilter(profileName) {
+			continue
+		}
+
+		overview, err := c.fetchProfileStatusOverview(ctx, profile.ID)
+		if err != nil {
+			c.logger.ErrorContext(ctx, "error fetching status overview for profile, skipping",
+				slog.String("profile_name", profileName),
+				slog.String("profile_id", profile.ID),
+				slog.Any("err", err),
+			)
+
+			continue
+		}
+
+		// Emit one metric per status type with count value
+		metrics = append(metrics, prometheus.MustNewConstMetric(
+			c.perProfileConfigurationDesc,
+			prometheus.GaugeValue,
+			float64(overview.SuccessCount),
+			profileName, "success",
+		))
+		metrics = append(metrics, prometheus.MustNewConstMetric(
+			c.perProfileConfigurationDesc,
+			prometheus.GaugeValue,
+			float64(overview.FailedCount),
+			profileName, "failed",
+		))
+		metrics = append(metrics, prometheus.MustNewConstMetric(
+			c.perProfileConfigurationDesc,
+			prometheus.GaugeValue,
+			float64(overview.ErrorCount),
+			profileName, "error",
+		))
+		metrics = append(metrics, prometheus.MustNewConstMetric(
+			c.perProfileConfigurationDesc,
+			prometheus.GaugeValue,
+			float64(overview.PendingCount),
+			profileName, "pending",
+		))
+		metrics = append(metrics, prometheus.MustNewConstMetric(
+			c.perProfileConfigurationDesc,
+			prometheus.GaugeValue,
+			float64(overview.NotApplicableCount),
+			profileName, "notApplicable",
+		))
+	}
+
+	duration := time.Since(start)
+
+	c.logger.InfoContext(ctx, "scraped per-profile configuration metrics",
+		slog.Int("profiles", len(profiles)),
+		slog.Int("metrics", len(metrics)),
+		slog.Duration("duration", duration),
+	)
+
+	return metrics, nil
+}
+
+func (c *Collector) matchesProfileFilter(profileName string) bool {
+	if len(c.profileFilter) == 0 {
+		return true
+	}
+
+	lowerName := strings.ToLower(profileName)
+
+	for _, pattern := range c.profileFilter {
+		matched, err := path.Match(pattern, lowerName)
+		if err != nil {
+			c.logger.Warn("invalid glob pattern in profile filter, skipping",
+				slog.String("pattern", pattern),
+				slog.Any("err", err),
+			)
+
+			continue
+		}
+
+		if matched {
+			return true
+		}
+	}
+
+	return false
+}
+
+func toLowerSlice(ss []string) []string {
+	out := make([]string, len(ss))
+
+	for i, s := range ss {
+		out[i] = strings.ToLower(s)
+	}
+
+	return out
 }

--- a/pkg/collectors/intune/intune_test.go
+++ b/pkg/collectors/intune/intune_test.go
@@ -44,7 +44,7 @@ func TestCollector_scrapeDevices(t *testing.T) {
 	httpClient := httpclient.New(prometheus.NewRegistry())
 	httpClient.WithAzureCredential(azureCredential)
 
-	collector := NewCollector(logger, tenantID, msGraphClient, httpClient.GetHTTPClient())
+	collector := NewCollector(logger, tenantID, msGraphClient, httpClient.GetHTTPClient(), Settings{})
 
 	// TODO: Go 1.24: Change to t.Context()
 	metrics, err := collector.scrapeDevices(context.Background())
@@ -78,7 +78,7 @@ func TestCollector_scrapeVppTokens(t *testing.T) {
 	httpClient := httpclient.New(prometheus.NewRegistry())
 	httpClient.WithAzureCredential(azureCredential)
 
-	collector := NewCollector(logger, tenantID, msGraphClient, httpClient.GetHTTPClient())
+	collector := NewCollector(logger, tenantID, msGraphClient, httpClient.GetHTTPClient(), Settings{})
 
 	// TODO: Go 1.24: Change to t.Context()
 	metrics, err := collector.scrapeVppTokens(context.Background())
@@ -115,7 +115,7 @@ func TestCollector_scrapeDepOnboardingSettings(t *testing.T) {
 	httpClient := httpclient.New(prometheus.NewRegistry())
 	httpClient.WithAzureCredential(azureCredential)
 
-	collector := NewCollector(logger, tenantID, msGraphClient, httpClient.GetHTTPClient())
+	collector := NewCollector(logger, tenantID, msGraphClient, httpClient.GetHTTPClient(), Settings{})
 
 	// TODO: Go 1.24: Change to t.Context()
 	metrics, err := collector.scrapeDepOnboardingSettings(context.Background())
@@ -151,7 +151,7 @@ func TestCollector_scrapeApplePushNotificationCertificate(t *testing.T) {
 	httpClient := httpclient.New(prometheus.NewRegistry())
 	httpClient.WithAzureCredential(azureCredential)
 
-	collector := NewCollector(logger, tenantID, msGraphClient, httpClient.GetHTTPClient())
+	collector := NewCollector(logger, tenantID, msGraphClient, httpClient.GetHTTPClient(), Settings{})
 
 	// TODO: Go 1.24: Change to t.Context()
 	metrics, err := collector.scrapeApplePushNotificationCertificate(context.Background())
@@ -165,5 +165,42 @@ func TestCollector_scrapeApplePushNotificationCertificate(t *testing.T) {
 	// If Apple Push Notification Certificate exists, we should see the metrics
 	if len(metrics) > 0 {
 		assert.Contains(t, allMetrics, "m365_intune_apn_expiry")
+	}
+}
+
+func TestCollector_scrapePerProfileConfiguration(t *testing.T) {
+
+	var (
+		ok       bool
+		tenantID string
+	)
+
+	if tenantID, ok = os.LookupEnv("AZURE_TENANT_ID"); !ok {
+		t.Skip("no AZURE_TENANT_ID environment variable set")
+	}
+
+	// TODO: Go 1.24: Change to slog.NewDiscardHandler
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	msGraphClient, azureCredential := getMSGraphClient(t)
+
+	httpClient := httpclient.New(prometheus.NewRegistry())
+	httpClient.WithAzureCredential(azureCredential)
+
+	collector := NewCollector(logger, tenantID, msGraphClient, httpClient.GetHTTPClient(), Settings{
+		PerProfileConfiguration: true,
+	})
+
+	// TODO: Go 1.24: Change to t.Context()
+	metrics, err := collector.scrapePerProfileConfiguration(context.Background())
+	require.NoError(t, err)
+
+	// Per-profile configuration metrics might be empty if no profiles exist
+	allMetrics, err := testutil.MetricsToText(t, metrics)
+	require.NoError(t, err)
+
+	// If configuration profiles exist, we should see the metrics
+	if len(metrics) > 0 {
+		assert.Contains(t, allMetrics, "m365_intune_device_configuration_overview")
 	}
 }

--- a/pkg/collectors/intune/intune_unit_test.go
+++ b/pkg/collectors/intune/intune_unit_test.go
@@ -1,0 +1,162 @@
+package intune
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMatchesProfileFilter(t *testing.T) {
+	tests := []struct {
+		name        string
+		filter      []string
+		profileName string
+		expected    bool
+	}{
+		{
+			name:        "empty filter matches all",
+			filter:      []string{},
+			profileName: "Windows Policy",
+			expected:    true,
+		},
+		{
+			name:        "exact match lowercase",
+			filter:      []string{"windows policy"},
+			profileName: "Windows Policy",
+			expected:    true,
+		},
+		{
+			name:        "glob pattern match",
+			filter:      []string{"windows*"},
+			profileName: "Windows Configuration Profile",
+			expected:    true,
+		},
+		{
+			name:        "no match",
+			filter:      []string{"ios*", "macos*"},
+			profileName: "Windows Policy",
+			expected:    false,
+		},
+		{
+			name:        "multiple patterns OR logic",
+			filter:      []string{"windows*", "apple*"},
+			profileName: "Apple Root CA",
+			expected:    true,
+		},
+		{
+			name:        "case insensitive",
+			filter:      []string{"WINDOWS*"},
+			profileName: "windows policy",
+			expected:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Collector{
+				profileFilter: toLowerSlice(tt.filter),
+			}
+			result := c.matchesProfileFilter(tt.profileName)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestToLowerSlice(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "empty slice",
+			input:    []string{},
+			expected: []string{},
+		},
+		{
+			name:     "mixed case",
+			input:    []string{"Windows*", "MACOS*", "iOS*"},
+			expected: []string{"windows*", "macos*", "ios*"},
+		},
+		{
+			name:     "already lowercase",
+			input:    []string{"test", "pattern"},
+			expected: []string{"test", "pattern"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := toLowerSlice(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestDeviceConfigurationStatusOverview_StructFields(t *testing.T) {
+	// Test that the overview struct has the expected fields and values
+	overview := &deviceConfigurationStatusOverview{
+		SuccessCount:       29,
+		FailedCount:        2,
+		ErrorCount:         1,
+		PendingCount:       3,
+		NotApplicableCount: 5,
+	}
+
+	// Verify all 5 status count fields are accessible
+	assert.Equal(t, 29, overview.SuccessCount)
+	assert.Equal(t, 2, overview.FailedCount)
+	assert.Equal(t, 1, overview.ErrorCount)
+	assert.Equal(t, 3, overview.PendingCount)
+	assert.Equal(t, 5, overview.NotApplicableCount)
+}
+
+func TestConfigValidation_InvalidGlobPattern(t *testing.T) {
+	// This tests that invalid glob patterns are handled (via path.Match error)
+	// The actual validation happens in NewCollector, but we can test the pattern
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	invalidPatterns := []string{
+		"windows[",    // unclosed bracket
+		"test[a-",     // incomplete range
+		"bad\\",       // trailing backslash
+	}
+
+	for _, pattern := range invalidPatterns {
+		c := &Collector{
+			logger:        logger,
+			profileFilter: []string{pattern},
+		}
+
+		// matchesProfileFilter should handle errors gracefully and skip bad patterns
+		// If all patterns are invalid, should return false
+		result := c.matchesProfileFilter("Windows Policy")
+
+		// Invalid patterns are skipped, so with only invalid patterns, nothing matches
+		assert.False(t, result, "invalid pattern should not match anything")
+	}
+}
+
+func TestConfigValidation_ValidGlobPatterns(t *testing.T) {
+	validPatterns := []string{
+		"windows*",
+		"*policy",
+		"test-[0-9]",
+		"app?config",
+	}
+
+	for _, pattern := range validPatterns {
+		c := &Collector{
+			profileFilter: []string{pattern},
+		}
+
+		// Just verify that valid patterns don't cause panics
+		// Actual matching is tested in TestMatchesProfileFilter
+		require.NotPanics(t, func() {
+			c.matchesProfileFilter("test string")
+		})
+	}
+}

--- a/pkg/conf/config.go
+++ b/pkg/conf/config.go
@@ -42,6 +42,9 @@ const (
 	KeyODriveEnabled        = "onedrive.enabled"
 	KeyApplicationEnabled   = "application.enabled"
 	KeyApplicationFilter    = "application.filter"
+
+	KeyIntunePerProfileConfiguration       = "intune.perProfileConfiguration"
+	KeyIntunePerProfileConfigurationFilter = "intune.perProfileConfigurationFilter"
 )
 
 // required in order to avoid global var.
@@ -76,6 +79,8 @@ func Configure(logger *slog.Logger) error {
 	v.SetDefault(KeyODriveEnabled, true)
 	v.SetDefault(KeyApplicationEnabled, true)
 	v.SetDefault(KeyApplicationFilter, nil)
+	v.SetDefault(KeyIntunePerProfileConfiguration, false)
+	v.SetDefault(KeyIntunePerProfileConfigurationFilter, nil)
 
 	v.SetEnvPrefix(envPrefix)
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))


### PR DESCRIPTION
Add opt-in metric exposing per-profile aggregate device configuration status via the deviceStatusOverview Graph API endpoint.

Config:

    intune.perProfileConfiguration (bool, default false)
    intune.perProfileConfigurationFilter ([]string, glob patterns)

Metric:

    m365_intune_device_configuration_overview{tenant, profile_name, status}

Status values:

* success
* failed
* error
* pending
* notApplicable

Closes #89